### PR TITLE
feat: make voting customizable

### DIFF
--- a/database/migrations/2018_04_03_211660_create_votes_table.php
+++ b/database/migrations/2018_04_03_211660_create_votes_table.php
@@ -14,7 +14,7 @@ class CreateVotesTable extends Migration
     public function up()
     {
         Schema::create('votes', function (Blueprint $table) {
-            $table->increments('id');
+            $table->unsignedInteger('id')->unique();
             $table->unsignedInteger('block_height_start')->unique();
             $table->unsignedInteger('block_height_end')->unique();
             $table->unsignedInteger('finished')->default(0);


### PR DESCRIPTION
This PR adds three new unsigned integer fields to the proposal that allow customizing the voting.

`network_vote_id`: the id to be used for the network vote (must be unique).
`network_vote_block_height_start`: the block height at which to start the vote.
`network_vote_block_height_end`: the block height at which to end the vote.